### PR TITLE
stackified, removed explicit lower bounds, effectively enabling usage…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ sample
 /.cabal-sandbox/
 /cabal.sandbox.config
 /dist/
+.stack-work

--- a/hadoop-rpc.cabal
+++ b/hadoop-rpc.cabal
@@ -61,7 +61,7 @@ library
     , socks                >= 0.5
     , stm                  >= 2.4
     , text                 >= 1.1
-    , transformers         >= 0.4
+    , transformers         >= 0.3
     , unix                 >= 2.7
     , unordered-containers >= 0.2
     , uuid                 >= 1.3.4

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,10 @@
+flags:
+  hadoop-rpc:
+    travis: false
+extra-package-dbs: []
+packages:
+- '.'
+extra-deps:
+- gsasl-0.3.6
+- protobuf-0.2.1.0
+resolver: lts-2.22


### PR DESCRIPTION
… with ghc-7.8

note: seemed to cause an additional dependency on the libgsasl system library, I have not tried to analyze the dependency graph for that